### PR TITLE
Force black color on labels instead of using body color

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -62,6 +62,7 @@
         font-family: Arial !important;
         background: #fff;
         left: -33px;
+        color: black;
       `;
       manipulators.upperLabel.style.cssText=`
         position: absolute;
@@ -70,6 +71,7 @@
         font-family: Arial !important;
         background: #fff;
         right: 0;
+        color: black;
       `;
       manipulators.selector.appendChild(manipulators.lowerLabel);
       manipulators.selector.appendChild(manipulators.upperLabel);


### PR DESCRIPTION
Hello, thanks for this extension.

I have noticed that the color of the manipulators labels is not defined and so uses the body color.
That makes those labels not visible on pages having a white body color, as the background is white.

Here is a small pull request to apply a black color to those labels.